### PR TITLE
bwlockmod.c: remove redundant initialization of "pinned"

### DIFF
--- a/bwlockmod.c
+++ b/bwlockmod.c
@@ -878,7 +878,6 @@ static struct perf_event *init_counter(int cpu, int budget)
 		.pinned		= 1,
 		.disabled	= 1,
 		.exclude_kernel = 1,   /* TODO: 1 mean, no kernel mode counting */
-		.pinned = 1,
 	};
 
 	if (!strcmp(g_hw_type, "core2")) {


### PR DESCRIPTION
Just cleanup, no functional changes.

Signed-off-by: Wang Xiaoqiang wangxq10@lzu.edu.cn
