### PR TITLE
bwlockmod.c: Fix warnning when compile

### DIFF
--- a/bwlockmod.c
+++ b/bwlockmod.c
@@ -266,7 +266,7 @@ static void bwlockmod_on_each_cpu_mask(const struct cpumask *mask,
 	}
 }
 
-static int __cpuinit bwlockmod_cpu_callback(struct notifier_block *nfb,
+static int bwlockmod_cpu_callback(struct notifier_block *nfb,
 					 unsigned long action, void *hcpu)
 {
 	unsigned int cpu = (unsigned long)hcpu;
@@ -284,7 +284,7 @@ static int __cpuinit bwlockmod_cpu_callback(struct notifier_block *nfb,
 	return NOTIFY_OK;
 }
 
-static struct notifier_block __cpuinitdata bwlockmod_cpu_notifier =
+static struct notifier_block bwlockmod_cpu_notifier =
 {
 	.notifier_call = bwlockmod_cpu_callback,
 };


### PR DESCRIPTION
when type `make' in bwlock, I get the following messages:

...
WARNING: /home/wangxq/repo/bwlock/bwlockmod.o(.text+0x2108):
Section mismatch in reference from the function init_module()
to the variable .cpuinit.data:bwlockmod_cpu_notifier
...
WARNING: /home/wangxq/repo/bwlock/bwlockmod.o(.text+0x233a):
Section mismatch in reference from the function cleanup_module()
to the variable .cpuinit.data:bwlockmod_cpu_notifier
...

This is because the inappropriate use of __cpuinit\* notation.
Since 'bwlockmod_cpu_notifier' is not only used in init_module,
but also used in cleanup_module.

Signed-off-by: Wang Xiaoqiang wangxq10@lzu.edu.cn
